### PR TITLE
Who We Are Padding

### DIFF
--- a/src/component/LandingPageV2/WhoWeAre/style.css
+++ b/src/component/LandingPageV2/WhoWeAre/style.css
@@ -4,29 +4,8 @@
     padding: 0%;
 }
 
-@media only screen and (max-device-width: 650px) {
-    .whoWeAreContainer {
-        width: 100%;
-        height: 25%;
-        margin: 0%;
-        padding: 0%;
-    }
-
-    .whowearetext {
-        padding-top: 25%;
-        padding-left: 15%;
-        font-family: 'Space Mono 700';
-        font-style: normal;
-        font-weight: 700;
-        font-size: 1vh;
-        line-height: 11.22vh;
-        text-transform: uppercase;
-        color: #FFFFFF;
-    }
-}
-
 .whowearetext {
-    padding-top: 25%;
+    /* padding-top: 25%; */
     padding-left: 15%;
     font-family: 'Space Mono 700';
     font-style: normal;
@@ -35,6 +14,8 @@
     line-height: 11.22vh;
     text-transform: uppercase;
     color: #FFFFFF;
+    position: absolute;
+    bottom: 15px;
 }
 
 .whowearetextmobile {
@@ -51,7 +32,8 @@
 
 .bluerectangle {
     height: 40vh;
-    background: #187DFF;;
+    background: #187DFF;
+    position: relative;
 }
 
 .purplerectangle {
@@ -73,4 +55,20 @@
     font-size: 2.92vh;
     line-height: 4.15vh;
     color: #FFFFFF;
+}
+
+@media only screen and (max-device-width: 650px) {
+    .whoWeAreContainer {
+        width: 100%;
+        height: 25%;
+        margin: 0%;
+        padding: 0%;
+    }
+
+    .whowearetext {
+        padding-top: 25%;
+        padding-left: 15%;
+        position: unset;
+        bottom: unset;
+    }
 }


### PR DESCRIPTION
 # What was the ticket?
 WT-83 - I worked on adding more space under the "Who We Are" text
 Link to Ticket: https://generatenu.atlassian.net/jira/software/projects/WT/boards/2?label=Zach&selectedIssue=WT-83
 
 # What did I do?
 
- Changed blue rectangle positioning to more easily move text
- Moved Who We Are text up to give it more spacing underneath it
- Moved mobile CSS to bottom of file so it isn't overridden by the desktop CSS, and removed duplicate styling
- Added mobile CSS to ensure mobile is unaffected by my changes
 
 # How did I test it?
 
 Key Parts
 - I resized the page on desktop both horizontally and vertically to ensure the placement of the text is still correct
 - I checked various mobile sizes to make sure mobile still looks good
 
 Required checks:
 
 - [X] Did you conduct a self-review?
 
 # Screenshots
 FIGMA
<img width="611" alt="image" src="https://user-images.githubusercontent.com/15839864/225752613-ef514e7e-dc07-4c89-ad71-67c8f66359e8.png">

 MY VERSION
![image](https://user-images.githubusercontent.com/15839864/225752682-56d0dc96-96e7-4946-8777-5936115bffdb.png)

Mobile is unaffected
![image](https://user-images.githubusercontent.com/15839864/225752807-138517eb-e003-402b-bf5a-3e03fe465ea6.png)
