### PR TITLE
Make arrow appear next to footer link based on current page

### DIFF
--- a/src/component/VerticalFooter/index.js
+++ b/src/component/VerticalFooter/index.js
@@ -32,12 +32,16 @@ function VerticalFooter() {
           <Row className="footer-text">
             {" "}
             <b>
-              <a href={"/"}>Generate {currentPage === "/" ? "<" : ""}</a>
+              <a href={"/"}>
+                Generate {currentPage === "/" ? "<" : ""}
+              </a>
             </b>
           </Row>
           <Row className="footer-text">
             {" "}
-            <a href="/about">About {currentPage === "/about" ? "<" : ""}</a>
+            <a href="/about">
+              About {currentPage === "/about" ? "<" : ""}
+            </a>
           </Row>
           <Row className="footer-text">
             {" "}
@@ -59,7 +63,9 @@ function VerticalFooter() {
           </Row>
           <Row className="footer-text">
             {" "}
-            <a href="/apply">Apply {currentPage === "/apply" ? "<" : ""}</a>
+            <a href="/apply">
+              Apply {currentPage === "/apply" ? "<" : ""}
+            </a>
           </Row>
           <Row className="footer-text">
             {" "}

--- a/src/component/VerticalFooter/index.js
+++ b/src/component/VerticalFooter/index.js
@@ -31,23 +31,33 @@ function VerticalFooter() {
         <span id="footer-pages">
           <Row className="footer-text">
             {" "}
-            <b>
-              <a href={"/"}>
-                Generate {currentPage === "/" ? "<" : ""}
-              </a>
-            </b>
+            {currentPage === "/" ? (
+              <b>
+                <a href={"/"}>Generate {"<"}</a>
+              </b>
+            ) : (
+              <a href={"/"}>Generate</a>
+            )}
           </Row>
           <Row className="footer-text">
             {" "}
-            <a href="/about">
-              About {currentPage === "/about" ? "<" : ""}
-            </a>
+            {currentPage === "/about" ? (
+              <b>
+                <a href={"/about"}>About {"<"}</a>
+              </b>
+            ) : (
+              <a href={"/about"}>About</a>
+            )}
           </Row>
           <Row className="footer-text">
             {" "}
-            <a href="/culture">
-              Culture {currentPage === "/culture" ? "<" : ""}
-            </a>
+            {currentPage === "/culture" ? (
+              <b>
+                <a href={"/culture"}>Culture {"<"}</a>
+              </b>
+            ) : (
+              <a href={"/culture"}>Culture</a>
+            )}
           </Row>
           <Row className="footer-text">
             {" "}
@@ -63,9 +73,13 @@ function VerticalFooter() {
           </Row>
           <Row className="footer-text">
             {" "}
-            <a href="/apply">
-              Apply {currentPage === "/apply" ? "<" : ""}
-            </a>
+            {currentPage === "/apply" ? (
+              <b>
+                <a href={"/apply"}>Apply {"<"}</a>
+              </b>
+            ) : (
+              <a href={"/apply"}>Apply</a>
+            )}
           </Row>
           <Row className="footer-text">
             {" "}

--- a/src/component/VerticalFooter/index.js
+++ b/src/component/VerticalFooter/index.js
@@ -11,6 +11,8 @@ import NortheasternIcon from "../../assets/images/socialMediaIcons/Northeaster.p
 import Sherm from "../../assets/images/socialMediaIcons/Sherm.png";
 
 function VerticalFooter() {
+  const currentPageUrl = window.location.href;
+  const currentPage = currentPageUrl.substring(currentPageUrl.lastIndexOf("/"));
   return (
     <Container fluid className="footer-container">
       <Row>
@@ -30,16 +32,18 @@ function VerticalFooter() {
           <Row className="footer-text">
             {" "}
             <b>
-              <a href={window.location.href}>Generate &lt;</a>
+              <a href={"/"}>Generate {currentPage === "/" ? "<" : ""}</a>
             </b>
           </Row>
           <Row className="footer-text">
             {" "}
-            <a href="/about">About </a>
+            <a href="/about">About {currentPage === "/about" ? "<" : ""}</a>
           </Row>
           <Row className="footer-text">
             {" "}
-            <a href="/culture">Culture</a>
+            <a href="/culture">
+              Culture {currentPage === "/culture" ? "<" : ""}
+            </a>
           </Row>
           <Row className="footer-text">
             {" "}
@@ -55,7 +59,7 @@ function VerticalFooter() {
           </Row>
           <Row className="footer-text">
             {" "}
-            <a href="/apply">Apply</a>
+            <a href="/apply">Apply {currentPage === "/apply" ? "<" : ""}</a>
           </Row>
           <Row className="footer-text">
             {" "}


### PR DESCRIPTION
 # What was the ticket?
Making an arrow appear next to page link in the footer based on current page
 
 # What did I do?
 Got the current URL and then added if statements for each link to determine if the `<` should display
 
 # How did I test it?
Went to each page to make sure arrow appeared correctly
 
 Required checks:
 
 - [X] Did you conduct a self-review?

# Screenshots
 MY VERSION
<img width="317" alt="image" src="https://user-images.githubusercontent.com/15839864/226778437-e0a640ac-bf3a-4e38-9dcf-b2ad22732110.png">

<img width="317" alt="image" src="https://user-images.githubusercontent.com/15839864/226778410-42debe14-ab6f-4fff-b0c8-2cb8f3bc7700.png">

<img width="317" alt="image" src="https://user-images.githubusercontent.com/15839864/226778477-a3bb35aa-d564-4d54-b815-7d196bb81003.png">

