### PR TITLE
FP1 resizing fix w/o interfering with mobile page

### DIFF
--- a/src/component/LandingPageV2/FP1/index.jsx
+++ b/src/component/LandingPageV2/FP1/index.jsx
@@ -5,39 +5,98 @@ import EarnzMockUp from "../../../assets/images/landingpage-v2/Earnz_Mock_Up.png
 import TopCorner from "../../../assets/images/landingpage-v2/top_corner.png";
 
 export default function FP1() {
-  return (
-    <div className="parent">
-      <div className="column-1">
-        <div>
-          <h1 style={{ fontSize: "7vh" }} className="earnz-header">
-            Earnz
-          </h1>
-          <p style={{ fontFamily: "Space Mono", fontSize: "3vh" }}>software</p>
-        </div>
-        <div className="client">
-          <p style={{ fontSize: "3vh" }} className="client-text">
-            Client
-          </p>
-          <div className="name-order">
-            <p style={{ fontSize: "3vh" }} className="name-text">
-              Max Thalheimer
-            </p>
-            <p style={{ fontSize: "2vh" }} className="school">
-              Northeastern Alumnus ‘20
-            </p>
+  if (window.innerWidth/window.innerHeight <= 0.6) {
+    return (
+      <div className="parent">
+        <div className="column-1">
+          <div>
+            <h1 style={{ fontSize: "7vh" }} className="earnz-header">
+              Earnz
+            </h1>
+            <p style={{ fontFamily: "Space Mono", fontSize: "3vh" }}>software</p>
           </div>
-        </div>
-        <div className="client-blurb" id="fp1-client-blurb">
-            <p style={{width: "40vh"}}>
+          <div className="client">
+            <p style={{ fontSize: "3vh" }} className="client-text">
+              Client
+            </p>
+            <div className="name-order">
+              <p style={{ fontSize: "3vh" }} className="name-text">
+                Max Thalheimer
+              </p>
+              <p style={{ fontSize: "2vh" }} className="school">
+                Northeastern Alumnus ‘20
+              </p>
+            </div>
+          </div>
+          <div className="client-blurb" id="fp1-client-blurb">
+            <p style={{ width: "40vh" }}>
               A unique, two-sided promotional and loyalty platform built to
               level the playing field for independent bars and restaurants by
               allowing them to utilize an app to acquire and retain customers as
               easily and cost effectively as currently only chains can.
             </p>
-          <a href="url">learn more</a>
+            <a href="url">learn more</a>
+          </div>
+          <div className="bottom-corner">
+            <img style={{ height: "25vh" }} src={BottomCorner} alt="" />
+          </div>
+        </div>
+        <div className="column-2">
+          <div className="product-img-container" id="fp1-img-container">
+            <img className="product-img" src={EarnzMockUp} alt="" />
+          </div>
+        </div>
+        <div className="column-3" id="fp1-c3">
+          <div className="top-corner">
+            <img
+              style={{ width: "60vh", height: "25vh" }}
+              src={TopCorner}
+              alt=""
+            />
+          </div>
+          <div className="quote-container" id="fp1-quote-container">
+            <blockquote>
+              Generate was great as a learning experience for me, as someone who
+              hadn’t built a tech company before. The team of experienced Generate
+              engineers knew what it takes to build a product like earnz, how to
+              package it all together, and ultimately how to come together as a
+              team.
+            </blockquote>
+          </div>
+          <hr id="pageSeparator"></hr>
+        </div>
+      </div>
+    );
+  } else {
+    return (
+    <>
+      <div className="column-1">
+        <div className="column-1-text">
+          <div>
+            <h1 style={{ fontSize: "9vh" }}>Earnz</h1>
+            <p style={{ fontFamily: "Space Mono", fontSize: "3vh" }}>
+              software
+            </p>
+          </div>
+          <div className="client">
+            <p style={{ fontSize: "3vh" }} className="client-text">Client</p>
+            <div className="name-order">
+              <p style={{ fontSize: "3vh" }} className="name-text">Max Thalheimer</p>
+              <p style={{ fontSize: "2vh" }} className="school">Northeastern Alumnus ‘20</p>
+            </div>
+          </div>
+          <div>
+            <p style={{ width: "40vh" }} className="client-blurb">
+              A unique, two-sided promotional and loyalty platform built to level
+              the playing field for independent bars and restaurants by allowing
+              them to utilize an app to acquire and retain customers as easily and
+              cost effectively as currently only chains can.
+            </p>
+            <a href="url">learn more</a>
+          </div>
         </div>
         <div className="bottom-corner">
-          <img style={{ height: "25vh" }} src={BottomCorner} alt="" />
+          <img className="bottom-corner-img" src={BottomCorner} alt="" />
         </div>
       </div>
       <div className="column-2">
@@ -47,25 +106,21 @@ export default function FP1() {
       </div>
       <div className="column-3" id="fp1-c3">
         <div className="top-corner">
-          <img
-            style={{ width: "60vh", height: "25vh" }}
-            src={TopCorner}
-            alt=""
-          />
+          <img className="top-corner-img" src={TopCorner} alt="" />
         </div>
-        <div className="quote-container" id="fp1-quote-container">
-          <blockquote>
+        <blockquote className="block_quote">
+          <div className="quote-container">
             Generate was great as a learning experience for me, as someone who
-            hadn’t built a tech company before. The team of experienced Generate
+            hadn't built a tech company before. The team of experienced Generate
             engineers knew what it takes to build a product like earnz, how to
             package it all together, and ultimately how to come together as a
             team.
-          </blockquote>
-        </div>
-        <hr id="pageSeparator"></hr>
+          </div>
+        </blockquote>
       </div>
-    </div>
-  );
+    </ >
+    );
+  }
 }
 
 // https://codesandbox.io/s/ryidb?file=/src/SlideShow.js for making the images a slideshow

--- a/src/component/LandingPageV2/FP1/style.css
+++ b/src/component/LandingPageV2/FP1/style.css
@@ -118,6 +118,173 @@ h1 {
   text-transform: uppercase;
 }
 
+@media only screen and (min-aspect-ratio: 6/10) {
+  .parent {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+    padding: 20vh;
+    background-color: white;
+  }
+  
+  .column-1 {
+    width: 60vh;
+    margin-top: -5vh;
+  }
+  
+  .column-1-text {
+    padding-top: 15vh;
+    padding-left: 25vh;
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .column-2 {
+    width: 70vh;
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .column-3 {
+    width: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .client {
+    width: 50vh;
+    flex-direction: row;
+    padding-top: 3%;
+  }
+  
+  .client-text {
+    font-family: Outfit 500;
+    font-size: 3vh;
+    line-height: 3vh;
+    ;
+    font-weight: 700;
+    padding-right: 2vh;
+  }
+  
+  .name-text {
+    font-family: Outfit 500;
+    font-size: 3vh;
+  }
+  
+  .school {
+    font-family: Outfit 500;
+    font-size: 2vh;
+    text-transform: uppercase;
+  }
+  
+  .name-order {
+    display: flex;
+    flex-direction: column;
+    margin-right: 10vh;
+  }
+  
+  .client-blurb {
+    width: 40vh;
+    padding-top: 6vh;
+    align-self: flex-end;
+    font-size: 3vh;
+  }
+  
+  .bottom-corner {
+    padding-bottom: 5vh;
+    align-self: flex-start;
+  }
+  
+  .bottom-corner-img {
+    margin-top: -23vh;
+    margin-left: 10vh;
+    height: 25vh;
+  }
+  
+  .product-img {
+    /* position: absolute; */
+    height: 80vh;
+    margin-top: -8vh;
+    margin-left: -4vh;
+    min-height: 100%;
+  }
+  
+  .product-img-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    padding-top: 5vh;
+    padding-left: 14vh;
+    margin-top: 14vh;
+  }
+  
+  .top-corner {
+    align-self: flex-end;
+    height: 40vh;
+  }
+  
+  .top-corner-img {
+    margin-top: 5vh;
+    margin-right: 8vh;
+    align-self: flex-end;
+    height: 25vh;
+  }
+  
+  blockquote {
+    font-family: "Outfit 300";
+    font-size: 2.5vh;
+    position: relative;
+    margin: 2vh;
+  }
+  
+  blockquote:before {
+    font-family: "Space Mono 700";
+    color: #ffbf3c;
+    position: absolute;
+    font-size: 6vh;
+    line-height: 1;
+    top: 0;
+    margin-left: -2vh;
+    left: -2vh;
+    content: "\201C";
+  }
+  
+  blockquote:after {
+    font-family: "Space Mono 700";
+    color: #ffbf3c;
+    position: absolute;
+    float: right;
+    font-size: 6vh;
+    margin-top: 2vh;
+    margin-right: 12vh;
+    line-height: 1;
+    right: 0vh;
+    bottom: -1vh;
+    content: "\201D";
+  }
+  
+  h1 {
+    font-family: "Space Mono";
+    font-style: normal;
+    font-weight: bolder;
+    font-size: 9vh;
+    line-height: 9vh;
+    text-transform: uppercase;
+  }
+  
+  .quote-container {
+    font-family: "Outfit 300";
+    font-size: 2.5vh;
+    position: relative;
+    margin: 2vh;
+    margin-left: 2vh;
+  }
+  
+  .block_quote {
+    margin-left: 13vh;
+  }
+}
+
 @media only screen and (max-device-width: 650px) {
   /*.parent {*/
   /*  flex-direction: column;*/


### PR DESCRIPTION
 # What was the ticket?
 WT-104 - Adding resizing fix for FP1 section on landing page
https://generatenu.atlassian.net/jira/software/projects/WT/boards/2?selectedIssue=WT-104
 
 # What did I do?
 
Made FP1 section resize correctly on desktop by adding in fixes from old resizing branch. Also needed to create a new structure so that changes for mobile page were preserved

 # How did I test it?

Resized page to smallest possible size and viewed page at different aspect ratios, then ensured text was still readable
 
Describe in detail steps you used to test the changes you have made.
Key Parts
 - Split section into separate dividers
 - Added a separate page structures for mobile and desktop
 - Changed some elements to scale off of height instead of width

 
 Required checks:
 
 - [Yes] Did you conduct a self-review?
 - [N/A] Have you written unit or integration tests?
=======

 # What could go wrong in the future? What parts of your code should the reviewer pay the most attention to?
 
 Describe aspects of the PR that may become problems in the future.
 Key Questions
 - Using separate views for mobile and desktop might be a concern in extremely high resolutions, but this is probably an extremely fringe case that likely won't occur. Even if it does, the fix is small.
 
 # Additional comments for the reviewers
 
 # Screenshots
 FIGMA
 ![alt text](public/images/PRImages/Figma_Earnz.png?raw=true "FIGMA") 

 MY VERSION
 ![alt text](public/images/PRImages/Earnz_SS_1.png?raw=true "LOCAL 1")
 ![alt text](public/images/PRImages/Earnz_SS_2.png?raw=true "LOCAL 2")
