### PR TITLE
FP2 resizing w/out interfering with mobile page

### DIFF
--- a/src/component/LandingPageV2/FP2/index.jsx
+++ b/src/component/LandingPageV2/FP2/index.jsx
@@ -5,54 +5,107 @@ import SmartyPillMockup from "../../../assets/images/landingpage-v2/SmartyPill M
 import TopCorner from "../../../assets/images/landingpage-v2/top_corner.png";
 
 export default function FP2() {
-  return (
-    <div className="parent">
-      <div className="column-1">
-        <div className="heading-container">
-          <h1 id="fp2-header">SmartyPill</h1>
-          <p id="fp2-teams">
-            software + hardware
-          </p>
-        </div>
-        <div className="client">
-          <p className="client-text">Client</p>
-          <div className="name-order">
-            <p style={{fontSize: "3vh"}} className="name-text">Matthew Swenson</p>
-            <p style={{fontSize: "2vh"}} className="school">Northeastern Alumnus ‘20</p>
+  if (window.innerWidth/window.innerHeight <= 0.6) {
+    return (
+      <div className="parent">
+        <div className="column-1">
+          <div className="heading-container">
+            <h1 id="fp2-header">SmartyPill</h1>
+            <p id="fp2-teams">
+              software + hardware
+            </p>
+          </div>
+          <div className="client">
+            <p className="client-text">Client</p>
+            <div className="name-order">
+              <p style={{fontSize: "3vh"}} className="name-text">Matthew Swenson</p>
+              <p style={{fontSize: "2vh"}} className="school">Northeastern Alumnus ‘20</p>
+            </div>
+          </div>
+          <div className="client-blurb" id="fp2-client-blurb">
+            <p style={{width: "40vh"}}>
+              SmartyPill is an automatic pill and water dispenser that ensures
+              you’re taking the right pills at the right time. With customizable
+              alerts and a connected app, SmartyPill is the perfect in-home
+              companion for any medication adherent lifestyle.
+            </p>
+            <a href="url">learn more</a>
+          </div>
+          <div className="bottom-corner">
+            <img style={{height: "25vh"}} src={BottomCorner} alt="" />
           </div>
         </div>
-        <div className="client-blurb" id="fp2-client-blurb">
-          <p style={{width: "40vh"}}>
-            SmartyPill is an automatic pill and water dispenser that ensures
-            you’re taking the right pills at the right time. With customizable
-            alerts and a connected app, SmartyPill is the perfect in-home
-            companion for any medication adherent lifestyle.
-          </p>
-          <a href="url">learn more</a>
+        <div className="column-2">
+          <div className="product-img-container">
+            <img className="mockup-img" src={SmartyPillMockup} alt="" />
+          </div>
         </div>
-        <div className="bottom-corner">
-          <img style={{height: "25vh"}} src={BottomCorner} alt="" />
+        <div className="column-3">
+          <div className="top-corner">
+            <img style={{height: "25vh"}} src={TopCorner} alt="Smarty_Pill"  width="45%"/>
+          </div>
+          <div className="quote-container">
+            <blockquote>
+              The biggest benefit that Generate provided for me was just the
+              amount of work that was put into SmartyPill, and the knowledge
+              gained from prototyping and writing software for it.
+            </blockquote>
+          </div>
         </div>
       </div>
-      <div className="column-2">
-        <div className="product-img-container">
-          <img className="mockup-img" src={SmartyPillMockup} alt="" />
+    );
+  } else {
+    return (
+      <>
+        <div className="column-1">
+          <div className="column-1-text">
+            <div>
+              <h1 style={{ fontSize: "9vh" }}>SmartyPill</h1>
+              <p style={{ fontFamily: "Space Mono", fontSize: "3vh" }}>
+                software + hardware
+              </p>
+            </div>
+            <div className="client">
+              <p className="client-text">Client</p>
+              <div className="name-order">
+                <p style={{ fontSize: "3vh" }} className="name-text">Matthew Swenson</p>
+                <p style={{ fontSize: "2vh" }} className="school">Northeastern Alumnus ‘20</p>
+              </div>
+            </div>
+            <div>
+              <p style={{ width: "40vh" }} className="client-blurb">
+                SmartyPill is an automatic pill and water dispenser that ensures
+                you’re taking the right pills at the right time. With customizable
+                alerts and a connected app, SmartyPill is the perfect in-home
+                companion for any medication adherent lifestyle.
+              </p>
+              <a href="url">learn more</a>
+            </div>
+          </div>
+          <div className="bottom-corner">
+            <img className="bottom-corner-img" src={BottomCorner} alt="" />
+          </div>
         </div>
-      </div>
-      <div className="column-3">
-        <div className="top-corner">
-          <img style={{height: "25vh"}} src={TopCorner} alt="Smarty_Pill"  width="45%"/>
+        <div className="column-2">
+          <div className="product-img-container">
+            <img className="mockup-img" src={SmartyPillMockup} alt="" />
+          </div>
         </div>
-        <div className="quote-container">
-          <blockquote>
-            The biggest benefit that Generate provided for me was just the
-            amount of work that was put into SmartyPill, and the knowledge
-            gained from prototyping and writing software for it.
+        <div className="column-3">
+          <div className="top-corner">
+            <img className="top-corner-img" src={TopCorner} alt="Smarty_Pill" width="45%" />
+          </div>
+          <blockquote className="block_quote">
+            <div className="quote-container">
+              The biggest benefit that Generate provided for me was just the
+              amount of work that was put into SmartyPill, and the knowledge
+              gained from prototyping and writing software for it.
+            </div>
           </blockquote>
         </div>
-      </div>
-    </div>
-  );
+      </ >
+    );
+  }
 }
 
 // https://codesandbox.io/s/ryidb?file=/src/SlideShow.js for making the images a slideshow

--- a/src/component/LandingPageV2/FP2/style.css
+++ b/src/component/LandingPageV2/FP2/style.css
@@ -145,6 +145,174 @@ h1 {
   font-size: 3vh;
 }
 
+@media only screen and (min-aspect-ratio: 6/10) {
+  .parent {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+    padding: 20vh;
+    background-color: white;
+  }
+  
+  .column-1 {
+    width: max(60vh, 600px);
+    margin-top: -3vh;
+  }
+  
+  .column-1-text {
+    padding-top: 15vh;
+    padding-left: 25vh;
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .column-2 {
+    width: 70vh;
+    display: flex;
+    flex-direction: column;
+    margin-left: 20vh;
+  }
+  
+  .column-3 {
+    width: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .client {
+    width: 50vh;
+    flex-direction: row;
+    padding-top: 3%;
+  }
+  
+  .client-text {
+    font-family: Outfit 500;
+    font-size: 3vh;
+    line-height: 3vh;
+    ;
+    font-weight: 700;
+    padding-right: 2vh;
+  }
+  
+  .name-text {
+    font-family: Outfit 500;
+    font-size: 3vh;
+  }
+  
+  .school {
+    font-family: Outfit 500;
+    font-size: 2vh;
+    text-transform: uppercase;
+  }
+  
+  .name-order {
+    display: flex;
+    flex-direction: column;
+    margin-right: 10vh;
+  }
+  
+  .client-blurb {
+    width: 40vh;
+    padding-top: 6vh;
+    align-self: flex-end;
+    font-size: 3vh;
+  }
+  
+  .bottom-corner {
+    padding-bottom: 5vh;
+    align-self: flex-start;
+  }
+  
+  .bottom-corner-img {
+    margin-top: -23vh;
+    margin-left: 10vh;
+    height: 25vh;
+  }
+  
+  .product-img {
+    /* position: absolute; */
+    height: 80vh;
+    margin-top: -8vh;
+    margin-left: -4vh;
+    min-height: 100%;
+  }
+  
+  .product-img-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    padding-top: 5vh;
+    padding-left: 14vh;
+    margin-top: 14vh;
+  }
+  
+  .top-corner {
+    align-self: flex-end;
+    height: 40vh;
+  }
+  
+  .top-corner-img {
+    margin-top: 5vh;
+    margin-right: 8vh;
+    align-self: flex-end;
+    height: 25vh;
+  }
+  
+  blockquote {
+    font-family: "Outfit 300";
+    font-size: 2.5vh;
+    position: relative;
+    margin: 2vh;
+  }
+  
+  blockquote:before {
+    font-family: "Space Mono 700";
+    color: #ffbf3c;
+    position: absolute;
+    font-size: 6vh;
+    line-height: 1;
+    top: 0;
+    margin-left: -2vh;
+    left: -2vh;
+    content: "\201C";
+  }
+  
+  blockquote:after {
+    font-family: "Space Mono 700";
+    color: #ffbf3c;
+    position: absolute;
+    float: right;
+    font-size: 6vh;
+    margin-top: 2vh;
+    margin-right: 12vh;
+    line-height: 1;
+    right: 0vh;
+    bottom: -1vh;
+    content: "\201D";
+  }
+  
+  h1 {
+    font-family: "Space Mono";
+    font-style: normal;
+    font-weight: bolder;
+    font-size: 9vh;
+    line-height: 9vh;
+    text-transform: uppercase;
+  }
+  
+  .quote-container {
+    font-family: "Outfit 300";
+    font-size: 2.5vh;
+    position: relative;
+    margin: 2vh;
+    margin-left: 2vh;
+  }
+  
+  .block_quote {
+    margin-left: 13vh;
+  }
+}
+
 @media only screen and (max-device-width: 650px) {
   .parent {
     flex-direction: column;


### PR DESCRIPTION
 # What was the ticket?
 WT-105 - Adding resizing fix for FP2 section on landing page
https://generatenu.atlassian.net/jira/software/projects/WT/boards/2?selectedIssue=WT-105
 
 # What did I do?
 
Made FP2 section resize correctly on desktop by adding in fixes from old resizing branch. Also needed to create a new structure so that changes for mobile page were preserved

 # How did I test it?

Resized page to smallest possible size and viewed page at different aspect ratios, then ensured text was still readable
 
Describe in detail steps you used to test the changes you have made.
Key Parts
 - Split section into separate dividers
 - Added a separate page structures for mobile and desktop
 - Changed some elements to scale off of height instead of width

 
 Required checks:
 
 - [Yes] Did you conduct a self-review?
 - [N/A] Have you written unit or integration tests?
=======

 # What could go wrong in the future? What parts of your code should the reviewer pay the most attention to?
 
 Describe aspects of the PR that may become problems in the future.
 Key Questions
 - Using separate views for mobile and desktop might be a concern in extremely high resolutions, but this is probably an extremely fringe case that likely won't occur. Even if it does, the fix is small.
 
 # Additional comments for the reviewers
 
 # Screenshots
 FIGMA
 ![alt text](public/images/PRImages/Figma_Earnz.png?raw=true "FIGMA") 

 MY VERSION
 ![alt text](public/images/PRImages/Earnz_SS_1.png?raw=true "LOCAL 1")
 ![alt text](public/images/PRImages/Earnz_SS_2.png?raw=true "LOCAL 2")
