### PR TITLE
Interested resize fix w/out mobile interference

### DIFF
--- a/src/component/LandingPageV2/Interested/index.jsx
+++ b/src/component/LandingPageV2/Interested/index.jsx
@@ -10,53 +10,53 @@ import ShadowedButton from "../../ShadowedButton";
 import leftcarrot from "../../LandingPageV2/Interested/chevron.png";
 
 const Interested = () => {
-  return (
-    <div className="bg-white interestedcontainer">
-      {/* <img src={QuestionMark}></img> */}
-      <div className="interestedText">Interested</div>
-      <div className="interestedflexbox">
-        <div className="interestedJoinNowBox">
-          <a href="/apply" className="joinCommunitytext">
-            join us
-          </a>
+  if (window.innerWidth/window.innerHeight <= 0.6) {
+    return (
+      <div className="bg-white interestedcontainer">
+        <div className="interestedText">Interested</div>
+        <div className="interestedflexbox">
+          <div className="interestedJoinNowBox">
+            <a href="/apply" className="joinCommunitytext">
+              join us
+            </a>
+          </div>
+          <span id="join-span">
+            <div className="leftcarrot">
+              <img id="join-carrot" src={leftcarrot} />
+            </div>
+            <div className="sentenceText">
+              Join a community that shares the same goal - turning ideas into
+              reality
+            </div>
+          </span>
         </div>
-        <span id="join-span">
-          <div className="leftcarrot">
-            <img id="join-carrot" src={leftcarrot} />
-          </div>
-          <div className="sentenceText">
-            Join a community that shares the same goal - turning ideas into
-            reality
-          </div>
-        </span>
-        {/* <div className="leftcarrot">
-        <img src={leftcarrot} height="50vh" width="50vw" />
       </div>
-      <div className="sentenceText">
-        Join a community that shares the same goal - turning ideas into reality
-      </div> */}
+    );
+  } else {
+    return (
+      <>
+      <div className="bg-white interestedcontainer">
+        <div className="interestedflexbox">
+          <div className="interestedText">Interested</div>
+          <div className="interestedJoinNowBox">
+            <a href="/apply" className="joinCommunitytext">
+              join us
+            </a>
+          </div>
+        </div>
       </div>
-    </div>
-
-    // <div className="bg-white vw-100 vh-100 py-4 px-5">
-    //   <Row className="vh-33 p-5">
-    //     <div className="interested-word text-uppercase">Interested</div>
-    //   </Row>
-
-    //   <Row className="vh-23 p-5">
-    //     <Col>
-    //       <div className="box">join us</div>
-    //     </Col>
-
-    //     <Col>
-    //       <div className="phrase-text">
-    //         Join a community that shares the same goal - turning ideas into
-    //         reality
-    //       </div>
-    //     </Col>
-    //   </Row>
-    // </div>
-  );
+  
+      <div className="bg-white questionMarkContainer">
+        <div className="leftcarrot">
+          <img style={{ width: "5vh" }} src={leftcarrot} />
+        </div>
+        <div className="sentenceText">
+          Join a community that shares the same goal - turning ideas into reality
+        </div>
+      </div>
+      </>
+    );
+  }
 };
 
 export default Interested;

--- a/src/component/LandingPageV2/Interested/style.css
+++ b/src/component/LandingPageV2/Interested/style.css
@@ -109,6 +109,125 @@ a {
   width: 4vh;
 }
 
+@media only screen and (min-aspect-ratio: 6/10) {
+  .interestedcontainer {
+    width: 65vh;
+    background-size: 80%;
+    background-position: 100% 30%;
+  }
+  
+  .questionMarkContainer {
+    width: 45vh;
+    margin-top: -11vh;
+  }
+  
+  a {
+    text-decoration: none;
+    color: #ffffff;
+  }
+  
+  .background-white {
+    background-color: white;
+  }
+  
+  
+  .interestedflexbox {
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .interestedText {
+    margin-left: 6%;
+    margin-top: 30vh;
+    font-family: 'Space Mono 700';
+    font-style: normal;
+    font-size: min(9vh, 15vw);
+    text-transform: uppercase;
+    color: black;
+  }
+  
+  .applyNowBox {
+    display: inline-block;
+    width: 34vh;
+    height: 10vh;
+    margin-left: 2vh;
+    margin-top: 20vh;
+    background: #187DFF;
+    border: 1px solid #111111;
+  }
+  
+  .blackRectangle {
+    display: inline-block;
+    width: 30vh;
+    height: 10vh;
+    background: black;
+    margin-left: 10vh;
+  }
+  
+  .sentenceText {
+    margin-left: -5vh;
+    margin-top: -10vh;
+    width: 40vh;
+    font-family: 'Outfit 300';
+    font-style: normal;
+    font-weight: 300;
+    font-size: 3vh;
+    color: black;
+    padding-left: 10%;
+  }
+  
+  .cooltriangle {
+    margin-left: -5vh;
+    margin-top: 15vh;
+  }
+  
+  .leftcarrot {
+    margin-left: -15vh;
+    margin-top: 70.5vh;
+  }
+  
+  
+  .interestedJoinNowBox {
+    width: 34vh;
+    height: 10vh;
+    margin-left: 10%;
+    margin-top: 20%;
+    padding-top: 4%;
+    background: #187DFF;
+    border: 1px solid #111111;
+    box-shadow: 15px 30px;
+  }
+  
+  .joinCommunitytext {
+    width: 20vh;
+    height: 4.5vh;
+    margin-left: 21%;
+    font-family: 'Space Mono 400';
+    font-style: normal;
+    /* font-weight: 400; */
+    
+    font-size: 4vh;
+    line-height: 6vh;
+  
+    /* White */
+  
+    color: #FFFFFF;
+  }
+  
+  .questionMark {
+    width: 10vh;
+    height: 10vh;
+    margin-top: -20vh;
+    margin-left: -20vh;
+    font-family: 'Space Mono 700';
+    font-style: normal;
+    font-size: 90vh;
+    text-transform: uppercase;
+    /* 24, 125, 255 is #187DFF blue in RGB instead of hex */
+    color: rgba(24, 125, 255, 0.2);
+  }
+}
+
 @media only screen and (max-device-width: 650px) {
   .interestedcontainer {
     width: 100%;


### PR DESCRIPTION
 # What was the ticket?
 WT-107 - Adding resizing fix for Interested section on landing page
https://generatenu.atlassian.net/jira/software/projects/WT/boards/2?selectedIssue=WT-107
 
 # What did I do?
 
Made Interested section resize correctly on desktop by adding in fixes from old resizing branch. Also needed to create a new structure so that changes for mobile page were preserved

 # How did I test it?

Resized page to smallest possible size and viewed page at different aspect ratios, then ensured text was still readable
 
Describe in detail steps you used to test the changes you have made.
Key Parts
 - Split section into separate dividers
 - Added a separate page structures for mobile and desktop
 - Changed some elements to scale off of height instead of width

 
 Required checks:
 
 - [Yes] Did you conduct a self-review?
 - [N/A] Have you written unit or integration tests?
=======

 # What could go wrong in the future? What parts of your code should the reviewer pay the most attention to?
 
 Describe aspects of the PR that may become problems in the future.
 Key Questions
 - Using separate views for mobile and desktop might be a concern in extremely high resolutions, but this is probably an extremely fringe case that likely won't occur. Even if it does, the fix is small.
 
 # Additional comments for the reviewers
 
 # Screenshots
 FIGMA
 ![alt text](public/images/PRImages/Figma_Earnz.png?raw=true "FIGMA") 

 MY VERSION
 ![alt text](public/images/PRImages/Earnz_SS_1.png?raw=true "LOCAL 1")
 ![alt text](public/images/PRImages/Earnz_SS_2.png?raw=true "LOCAL 2")
