### PR TITLE
Footer and next page resize correctly

### DIFF
--- a/src/component/NextPage/index.jsx
+++ b/src/component/NextPage/index.jsx
@@ -6,13 +6,11 @@ import Arrow from "../../assets/images/nextpage/arrow.svg";
 export default function NextPage(props) {
   return (
     <div className="nextPage">
-      <a href={props.url}>
-        <button className="nextPageButton">
+        <a className="nextPageButton" href={props.url}>
           <img src={Arrow} className={"nextPageArrow"}></img>
           <span className={"nextPageName"}>{props.pageName}</span>
           <img src={Arrow} className={"nextPageArrow"}></img>
-        </button>
-      </a>
+        </a>
     </div>
   );
 }

--- a/src/component/NextPage/style.css
+++ b/src/component/NextPage/style.css
@@ -1,16 +1,17 @@
 .nextPage {
     background: #FFBF3C;
-    width: calc(18vw + 2vh);
+    width: 21.5vh;
     position: relative;
     height: 100vh;
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
     padding: 3% 4%;
 }
 
 .nextPage a {
-    width: 100%;
+    width: 12vh;
     height: 100%;
 }
 
@@ -23,10 +24,8 @@
     align-items: center;
     padding: 20%;
     box-sizing: border-box;
-    width: calc(100% - 2vh);
     height: 100%;
     flex-direction: column;
-    margin-left: 2vh;
     box-shadow: -1vh 1vh 0 0 #ffbf3c, -1vh 1vh 0 2px black;
 }
 
@@ -61,5 +60,11 @@
         width: 100vw;
         height: unset;
         padding: 10% 5%;
+    }
+
+    .nextPage a {
+        margin-left: 0.5vh;
+        width: 90vw;
+        height: 100%;
     }
 }

--- a/src/component/VerticalFooter/style.css
+++ b/src/component/VerticalFooter/style.css
@@ -5,7 +5,7 @@ a {
 
 .footer-container {
   background-color: #187dff;
-  width: 18vw;
+  width: 36vh;
   text-align: left;
   float: left;
 }
@@ -58,8 +58,8 @@ a:hover {
 }
 
 .social-icons {
-  margin-top: 50%;
-  margin-left: 20%;
+  margin-top: 30%;
+  margin-left: 27%;
   margin-right: 40%;
 }
 


### PR DESCRIPTION
 # What was the ticket?
N/A, Part of Landing page resizing
 
 # What did I do?
 
Made footer and next page sections resize correctly on desktop by adding in fixes from old resizing branch.

 # How did I test it?

Resized page to smallest possible size and viewed page at different aspect ratios, then ensured text was still readable
 
Describe in detail steps you used to test the changes you have made.
Key Parts
 - Split section into separate dividers
 - Changed some elements to scale off of height instead of width

 
 Required checks:
 
 - [Yes] Did you conduct a self-review?
 - [N/A] Have you written unit or integration tests?
=======

 # What could go wrong in the future? What parts of your code should the reviewer pay the most attention to?
 
 Describe aspects of the PR that may become problems in the future.
 Key Questions
 - Nothing obvious
 
 # Additional comments for the reviewers
 
 # Screenshots
 FIGMA
 ![alt text](public/images/PRImages/Figma_Earnz.png?raw=true "FIGMA") 

 MY VERSION
 ![alt text](public/images/PRImages/Earnz_SS_1.png?raw=true "LOCAL 1")
 ![alt text](public/images/PRImages/Earnz_SS_2.png?raw=true "LOCAL 2")
