### PR TITLE
Origin/bug fix/what we padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react-card-flip": "^1.1.5",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.0.1",
-    "react-scripts": "4.0.3",
+    "react-scripts": "^5.0.1",
     "web-vitals": "^1.1.2"
   },
   "scripts": {

--- a/src/component/AboutPage/WeAreSection/index.jsx
+++ b/src/component/AboutPage/WeAreSection/index.jsx
@@ -7,6 +7,7 @@ const WeAreSection = () => {
     return (
         <> 
              <div >
+             <div className='mission-header-space'></div>
                 <div className="weare-header fit-content">
                     <h5 className="mb-0 our-mission-our-values we-are-values w-auto h-auto text-end p-4">
                         our values

--- a/src/component/AboutPage/WeAreSection/style.css
+++ b/src/component/AboutPage/WeAreSection/style.css
@@ -60,7 +60,7 @@
 }
 
 .we-are-header-space {
-    height: 20vh;
+    height: 10vh;
 }
 
 .cards-space {

--- a/src/component/LandingPageV2/Introduction/index.jsx
+++ b/src/component/LandingPageV2/Introduction/index.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import "./style.css";
 import NavBar from "../../NavBar";
-import ScrollButton from "../../../assets/images/landingpage-v2/scrollword.png";
 
 /**
  * Added "MOBILE PAGE COMING SOON" element to display on mobile
@@ -19,13 +18,6 @@ export default function Introduction() {
           </div>
           <div class="comingsoontext">
             <p className="comingsoontext">MOBILE PAGE COMING SOON!</p>
-          </div>
-          {/* <div className="whitebox">
-             <div className="scrollarrow" ></div>
-             <p className="scrolltext">scroll</p>
-             </div> */}
-          <div className="scroll">
-            <img className="scrollimg" src={ScrollButton} alt="sroll left" />
           </div>
         </div>
       </div>

--- a/src/component/LandingPageV2/WhatWeOffer/index.jsx
+++ b/src/component/LandingPageV2/WhatWeOffer/index.jsx
@@ -34,7 +34,7 @@ const WhatWeOffer = () => {
           <div className="text-center">
             <div className="position-relative vh-30">
               <div
-                className="position-absolute bottom-0 text-black w-100 text-uppercase what-we-offer-style"
+                className="position-absolute bottom-0 p-1 text-black w-100 text-uppercase what-we-offer-style"
                 // onMouseEnter={() => setHighlightSoftware(true)}
                 // onMouseLeave={() => setHighlightSoftware(false)}
               >

--- a/src/data/directorData.js
+++ b/src/data/directorData.js
@@ -1,8 +1,4 @@
 // Directors' profile pictures
-import KathrynMinor from "../assets/images/landingpage/directorscarousel/KathrynMinor.jpg";
-import AvitalBrodski from "../assets/images/landingpage/directorscarousel/AvitalBrodski.jpg";
-import AndrewCataldo from "../assets/images/landingpage/directorscarousel/AndrewCataldo.jpg";
-import ThomasKeith from "../assets/images/landingpage/directorscarousel/ThomasKeith.jpg";
 import Ben from "../assets/images/aboutpage/Ben.jpeg";
 import Josh from "../assets/images/aboutpage/Josh.jpg";
 import Kyle from "../assets/images/aboutpage/Kyle.png";
@@ -11,13 +7,11 @@ import Victoria from "../assets/images/aboutpage/Victoria.JPG";
 
 // Team icons
 import ManagementActiveIcon from "../assets/icons/teams/colored/Management.png";
-import OutreachActiveIcon from "../assets/icons/teams/colored/Outreach.png";
 import OperationsActiveIcon from "../assets/icons/teams/colored/Operations.png";
 import SoftwareActiveIcon from "../assets/icons/teams/colored/Software.png";
 import HardwareActiveIcon from "../assets/icons/teams/colored/Hardware.png";
 import CommunityActiveIcon from "../assets/icons/teams/colored/Community.png";
 import ManagementInactiveIcon from "../assets/icons/teams/gray/Management.png";
-import OutreachInactiveIcon from "../assets/icons/teams/gray/Outreach.png";
 import OperationsInactiveIcon from "../assets/icons/teams/gray/Operations.png";
 import SoftwareInactiveIcon from "../assets/icons/teams/gray/Software.png";
 import HardwareInactiveIcon from "../assets/icons/teams/gray/Hardware.png";


### PR DESCRIPTION
- added padding to what we on landing page
![Screenshot 2023-03-30 at 9 10 53 PM](https://user-images.githubusercontent.com/56982656/228998110-0cd4e127-e0ad-44de-853f-8b14ffe325a7.png)

- moved our values about a little below
![Screenshot 2023-03-30 at 9 12 52 PM](https://user-images.githubusercontent.com/56982656/228998089-dadefa3f-8441-408d-88a3-3ce155cd642a.png)

- removed the scroll button
![Screenshot 2023-03-30 at 9 12 29 PM](https://user-images.githubusercontent.com/56982656/228998068-fcbebbf3-b93d-4aec-ab10-66e055b69747.png)



 # What was the ticket?

UI Design: Add bottom padding to "What We" text on desktop. 
 # What did I do?
 
Created a new Teams component and routed it to "/teams"
Ensured the page was based off the design in the figma and followed standards
present in the rest of the website, like horizontal scrolling, and smooth resizing
 
 # How did I test it?
 
Describe in detail steps you used to test the changes you have made.

Compared page in Figma with created page to ensure same structure was kept
For resizing, looked at smallest possible size to ensure the page looked nice even at that ratio
 
 Required checks:
 
 - [Yes] Did you conduct a self-review?
 - [N/A] Have you written unit or integration tests?
=======

 # What could go wrong in the future? What parts of your code should the reviewer pay the most attention to?
 
 Describe aspects of the PR that may become problems in the future.
 - None of the pictures are mapped to any of the specific teams pages, since those haven't been made yet
 - Used placeholder images that need to be replaced
 
 # Additional comments for the reviewers
 
 # Screenshots
 FIGMA
 ![alt text](public/images/PRImages/FigmaScreenshot.png?raw=true "FIGMA") 

 MY VERSION
 ![alt text](public/images/PRImages/TeamsScreenshot1.png?raw=true "SS 1")
 ![alt text](public/images/PRImages/TeamsScreenshot2.png.png?raw=true "SS 2")
