### PR TITLE
removed 'we are generate' from landing mobile panel

### DIFF
--- a/src/component/LandingPageV2/Introduction/style.css
+++ b/src/component/LandingPageV2/Introduction/style.css
@@ -347,6 +347,14 @@
     justify-content: center;
   }
 
+  .comingsoontext {
+    display: inline;
+  }
+
+  .desktop {
+    display: none;
+  }
+
   .intro-navbar {
     position: fixed;
     left: 50%;


### PR DESCRIPTION
 # What was the ticket?
 WT-65 - Andy and Sebastian worked on implementing the Teams page based on the figma diagram
 Link to Ticket: https://generatenu.atlassian.net/jira/software/projects/WT/boards/2?selectedIssue=WT-65
 
 # What did I do?
 
Created a new Teams component and routed it to "/teams"
Ensured the page was based off the design in the figma and followed standards
present in the rest of the website, like horizontal scrolling, and smooth resizing
 
 # How did I test it?
 
Describe in detail steps you used to test the changes you have made.

Compared page in Figma with created page to ensure same structure was kept
For resizing, looked at smallest possible size to ensure the page looked nice even at that ratio
 
 Required checks:
 
 - [Yes] Did you conduct a self-review?
 - [N/A] Have you written unit or integration tests?
=======

 # What could go wrong in the future? What parts of your code should the reviewer pay the most attention to?
 
 Describe aspects of the PR that may become problems in the future.
 - None of the pictures are mapped to any of the specific teams pages, since those haven't been made yet
 - Used placeholder images that need to be replaced
 
 # Additional comments for the reviewers
 
 # Screenshots
 FIGMA
 ![alt text](public/images/PRImages/FigmaScreenshot.png?raw=true "FIGMA") 

 MY VERSION
 ![alt text](public/images/PRImages/TeamsScreenshot1.png?raw=true "SS 1")
 ![alt text](public/images/PRImages/TeamsScreenshot2.png.png?raw=true "SS 2")
