### PR TITLE
fixed Earnz bottom left border moving offscreen

### DIFF
--- a/src/component/LandingPageV2/FP1/index.jsx
+++ b/src/component/LandingPageV2/FP1/index.jsx
@@ -29,7 +29,7 @@ export default function FP1() {
             </div>
           </div>
           <div className="client-blurb" id="fp1-client-blurb">
-            <p style={{ width: "40vh" }}>
+            <p style={{ width: "50vh" }}>
               A unique, two-sided promotional and loyalty platform built to
               level the playing field for independent bars and restaurants by
               allowing them to utilize an app to acquire and retain customers as
@@ -86,7 +86,7 @@ export default function FP1() {
             </div>
           </div>
           <div>
-            <p style={{ width: "40vh" }} className="client-blurb">
+            <p style={{ width: "43vh" }} className="client-blurb">
               A unique, two-sided promotional and loyalty platform built to level
               the playing field for independent bars and restaurants by allowing
               them to utilize an app to acquire and retain customers as easily and

--- a/src/component/LandingPageV2/FP1/style.css
+++ b/src/component/LandingPageV2/FP1/style.css
@@ -55,7 +55,7 @@
 }
 
 .client-blurb {
-  width: 40vh;
+  width: 43vh;
   padding-top: 6vh;
   align-self: flex-end;
 }
@@ -184,7 +184,7 @@ h1 {
   }
   
   .client-blurb {
-    width: 40vh;
+    width: 44vh;
     padding-top: 6vh;
     align-self: flex-end;
     font-size: 3vh;
@@ -196,7 +196,7 @@ h1 {
   }
   
   .bottom-corner-img {
-    margin-top: -23vh;
+    margin-top: -25vh;
     margin-left: 10vh;
     height: 25vh;
   }


### PR DESCRIPTION
# What was the ticket?
Fixed earnz bottom left corner being hidden offscreen.
 
 # What did I do?
 
I increased the width of the client blurb on "Earnz" to allow the corner component to flow onto screen.
 
 # How did I test it?
 
 I resized the screen to narrow viewport heights and widths, zoomed in and out to the max values, and checked using mobile inspect.

 # What could go wrong in the future? What parts of your code should the reviewer pay the most attention to?

 Whether the relative positioning of the header texts and the cards is appropriate
 
 # Additional comments for the reviewers
 I implemented a decent mobile look, although the styling will be changed entirely in a different ticket.
 
 # Screenshots

 MY VERSION
Large desktop:
<img width="1115" alt="image" src="https://user-images.githubusercontent.com/64978328/232239710-1da266f0-66f2-41ee-b8e9-afd0d7e90b4e.png">
Reg. desktop:
<img width="1010" alt="image" src="https://user-images.githubusercontent.com/64978328/232239751-760ebee8-5d68-4a1d-8808-15710df76998.png">

