### PR TITLE
Growth Mantra look / feel changes, hotfix

### DIFF
--- a/src/component/AboutPage/GrowthMantra/index.jsx
+++ b/src/component/AboutPage/GrowthMantra/index.jsx
@@ -8,55 +8,59 @@ import "./style.css";
 const GrowthMantra = () => {
   return (
     // <div className="position-relative vw-100 vh-100 py-4 px-5">
-    <div className="bg-white growthMantraContainer">
-      <div className="alignItemsRight">
-        <div className="mantra">
-          <p className="Growth-text">Growth</p>
-          <p className="IsOurText">Is Our</p>
-          <p className="MantraText">Mantra</p>
-        </div>
+    <div className="h-100 background-fit-content">
+      <div className="bg-white h-100 growthMantraContainer">
+        <div className="alignItemsRightMantra">
+          <div className="mantra">
+            <p className="Growth-text">Growth</p>
+            <p className="IsOurText">Is Our</p>
+            <p className="MantraText">Mantra</p>
+          </div>
         {/* <div className="growthMantrainterestedText">Interested</div> */}
+        </div>
+
+        {/* <div className="paragraphText">Our values arent just surface level but run deep throughout our organization. We always encourage our members to take on new challenges. Tools and resources are only an ask away, and members can test out their ideas to drive development.</div> */}
+        <div className="textAlignItemsRight">
+          {/* <div className= "paragraphTextTwo">Teams work side-by-side to ensure products and processes are beyond expectations. We are self-driven and help one another reach goals and become leaders. Not only do we build products, but we also build community, leadership, and opportunities.</div> */}
+          <div className="mantraParagraphText">
+            Our values arent just surface level but run deep throughout our
+            organization. We always encourage our members to take on new
+            challenges. Tools and resources are only an ask away, and members can
+            test out their ideas to drive development.
+          </div>
+
+          {/* <div className= "paragraphTextTwo">Teams work side-by-side to ensure products and processes are beyond expectations. We are self-driven and help one another reach goals and become leaders. Not only do we build products, but we also build community, leadership, and opportunities.</div> */}
+          <div className="mantraParagraphText" style={{marginRight: "0px"}}>
+            Teams work side-by-side to ensure products and processes are beyond
+            expectations. We are self-driven and help one another reach goals and
+            become leaders. Not only do we build products, but we also build
+            community, leadership, and opportunities.
+          </div>
+          {/* <div className="cooltriangle">
+                <img src={cooltriangle} height="400vh" width="600vw"/> 
+              </div> */}
+
+          {/* <div className="applyNowBoxGrowthMantra">
+            <a href="/apply" className="applyNowText">
+              apply now
+            </a>
+          </div>
+
+          <div className="carrot">
+            <img src={leftcarrot} />
+          </div> */}
+
+          {/* <div className="paragraphTextThree">
+            Join a community that shares the same goal - turning ideas into
+            reality
+          </div> */}
+          <img className="m-img" src={mountains} alt=""/>
+        </div>
+
       </div>
 
-      {/* <div className="paragraphText">Our values arent just surface level but run deep throughout our organization. We always encourage our members to take on new challenges. Tools and resources are only an ask away, and members can test out their ideas to drive development.</div> */}
-      <div className="alignItemsRight">
-        {/* <div className= "paragraphTextTwo">Teams work side-by-side to ensure products and processes are beyond expectations. We are self-driven and help one another reach goals and become leaders. Not only do we build products, but we also build community, leadership, and opportunities.</div> */}
-        <div className="paragraphTextGrowthMantra">
-          Our values arent just surface level but run deep throughout our
-          organization. We always encourage our members to take on new
-          challenges. Tools and resources are only an ask away, and members can
-          test out their ideas to drive development.
-        </div>
-
-        {/* <div className= "paragraphTextTwo">Teams work side-by-side to ensure products and processes are beyond expectations. We are self-driven and help one another reach goals and become leaders. Not only do we build products, but we also build community, leadership, and opportunities.</div> */}
-        <div className="paragraphTextGrowthMantraTwo">
-          Teams work side-by-side to ensure products and processes are beyond
-          expectations. We are self-driven and help one another reach goals and
-          become leaders. Not only do we build products, but we also build
-          community, leadership, and opportunities.
-        </div>
-        {/* <div className="cooltriangle">
-              <img src={cooltriangle} height="400vh" width="600vw"/> 
-            </div> */}
-
-        {/* <div className="applyNowBoxGrowthMantra">
-          <a href="/apply" className="applyNowText">
-            apply now
-          </a>
-        </div>
-
-        <div className="carrot">
-          <img src={leftcarrot} />
-        </div> */}
-
-        {/* <div className="paragraphTextThree">
-          Join a community that shares the same goal - turning ideas into
-          reality
-        </div> */}
-      </div>
-
-      <div className="mountain-image">
-        <img className="m-img" src={mountains} />
+      <div className="mtn-image">
+        <img className="m-img" src={mountains} alt=""/>
       </div>
     </div>
   );

--- a/src/component/AboutPage/GrowthMantra/index.jsx
+++ b/src/component/AboutPage/GrowthMantra/index.jsx
@@ -8,10 +8,10 @@ import "./style.css";
 const GrowthMantra = () => {
   return (
     // <div className="position-relative vw-100 vh-100 py-4 px-5">
-    <div className="h-100 background-fit-content">
-      <div className="bg-white h-100 growthMantraContainer">
+    <div className="background-fit-content">
+      <div className="background-white growthMantraContainer">
         <div className="alignItemsRightMantra">
-          <div className="mantra">
+          <div className="mantraAlignment">
             <p className="Growth-text">Growth</p>
             <p className="IsOurText">Is Our</p>
             <p className="MantraText">Mantra</p>

--- a/src/component/AboutPage/GrowthMantra/style.css
+++ b/src/component/AboutPage/GrowthMantra/style.css
@@ -2,96 +2,88 @@ a {
     text-decoration: none;
     color: #ffffff;
     z-index: 1;
-  }
-  .background-white {
+}
+
+.background-white {
     background-color: white;
     z-index: -10;
-  }
-
-.growthMantraContainer{
-  width: 130%;
 }
-  .Growth-text {
-    width: 1103px;
-    height: 444px;
-    z-index: 1;
-    left: 110px;
-    margin-top: -51px;
-    /* top: -51px; */
 
+.background-fit-content {
+    width: fit-content;
+}
+
+.growthMantraContainer {
+    width: 155vw;
+    margin-right: 12vw;
+}
+
+.Growth-text {
+    width: 1103px;
+    z-index: 1;
+    margin-bottom: 0px;
+    /* top: -51px; */
     font-family: 'Space Mono 700';
     font-style: normal;
     /* font-weight: 700; */
-    font-size: 200px;
-    line-height: 340px;
+    font-size: max(30vh, 300px);
+    line-height: 80%;
     text-transform: uppercase;
-
     /* OPRATN Green */
-
     color: #6FCF97;
-  }
+}
 
-  .IsOurText {
-    width: 338px;
-    height: 92px;
+.IsOurText {
+    width: 40vw;
     left: 124px;
-    margin-top: -230px;
     z-index: 1;
     /* top: 288px; */
     -webkit-text-fill-color: transparent;
-    -webkit-text-stroke-width: 1.5px;
+    -webkit-text-stroke-width: max(0.2vh, 1.5px);
     /* H1 */
-
     font-family: 'Space Mono 700';
     font-style: normal;
     font-weight: 700;
-    font-size: 70px;
+    font-size: max(9vh, 92px);
+    line-height: 95%;
+    margin-bottom: 0px;
     text-transform: uppercase;
+}
 
-  }
-
-  .MantraText {
-    width: 735px;
-    height: 296px;
+.MantraText {
+    width: 50vw;
+    height: auto;
     left: 126px;
-    top: 302px;
-    margin-top: -100px;
     z-index: 1;
-
+    margin-top: -40px;
     font-family: 'Space Mono 700';
     font-style: normal;
     /* font-weight: 700; */
-    font-size: 150px;
-    line-height: 260px;
+    font-size: max(20vh, 200px);
+    margin-bottom: 0px;
+    line-height: 90%;
     text-transform: uppercase;
-
     /* Black */
-
     color: #111111;
-  }
+}
 
-  .paragraphTextGrowthMantra {
+.paragraphTextGrowthMantra {
     width: 300px;
-    height: 238px;
+    height: 40vh;
     z-index: 1;
     /* margin-left: 10px; */
-    top: 567px;
-    margin-top: -60px;
     /* B1 */
-
     font-family: 'Outfit 300';
     font-style: normal;
     /* font-weight: 300; */
     font-size: 18px;
     line-height: 141.667%;
     /* or 142% */
-
-
     /* Black */
-
     color: black;
-  }
-  .paragraphTextGrowthMantraTwo {
+}
+
+.paragraphTextGrowthMantraTwo {
     width: 300px;
     height: 238px;
     margin-left: 60px;
@@ -99,26 +91,36 @@ a {
     margin-top: -60px;
     z-index: 1;
     /* B1 */
-
     font-family: 'Outfit 300';
     font-style: normal;
     /* font-weight: 300; */
     font-size: 18px;
     line-height: 141.667%;
     /* or 142% */
-
-
     /* Black */
-
     color: black;
-  }
+}
 
-  .carrot{
+.carrot {
     margin-left: 20px;
     z-index: 1;
-  }
+}
 
-  .paragraphTextTwo {
+.mantraParagraphText {
+    width: 30vw;
+    height: 30vh;
+    margin-right: 3vw;
+    text-align: left;
+    font-family: 'Outfit 300';
+    font-size: max(1vw + 1vh, 24px);
+    font-style: normal;
+    font-weight: 300;
+    line-height: 140%;
+    color: #111111;
+    z-index: 3;
+}
+
+.paragraphTextTwo {
     width: 415px;
     height: 400px;
     margin-left: 30px;
@@ -127,8 +129,7 @@ a {
     text-align: right;
     margin-right: -50px;
     /* B1 */
-
-    font-family: 'Outfit 300';    
+    font-family: 'Outfit 300';
     font-style: normal;
     /* font-weight: 300; */
     font-size: 18px;
@@ -136,9 +137,9 @@ a {
     /* or 142% */
     color: #111111;
     z-index: 1;
-  }
+}
 
-  .growthMantrainterestedText {
+.growthMantrainterestedText {
     font-family: 'Space Mono 700';
     font-style: normal;
     font-size: 5rem;
@@ -146,25 +147,41 @@ a {
     color: black;
     margin-top: 12%;
     z-index: 1;
-  }
+}
 
-  .mantra{
+.mantra {
     display: flex;
     flex-direction: column;
+    padding-top: 12vh;
     width: 60%;
     z-index: 1;
-  }
+}
 
-  .alignItemsRight {
+.alignItemsRightMantra {
     display: flex;
     flex-direction: row;
+    margin-right: 0;
+    margin-top: 0px;
+    align-items: flex-start;
     padding-left: 5%;
     padding-right: 5%;
     color: #000000;
     z-index: 1;
-  }
+}
 
-  .applyNowBoxGrowthMantra {
+.textAlignItemsRight {
+    padding-top: 5vh;
+    height: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    padding-left: 5%;
+    padding-right: 5%;
+    color: #000000;
+    z-index: 1;
+}
+
+.applyNowBoxGrowthMantra {
     display: inline-block;
     width: 200px;
     height: 50px;
@@ -175,9 +192,9 @@ a {
     /* Black */
     border: 1px solid #111111;
     z-index: 15;
-  }
+}
 
-  .blackRectangle {
+.blackRectangle {
     display: inline-block;
     width: 200px;
     height: 50px;
@@ -185,9 +202,9 @@ a {
     background: black;
     border: 1px solid #111111;
     z-index: 1;
-  }
+}
 
-  .applyNowText {
+.applyNowText {
     width: 134.68px;
     height: 36.4px;
     margin-left: 25px;
@@ -197,21 +214,18 @@ a {
     font-size: 24px;
     line-height: 36px;
     text-align: center;
-
     /* White */
-
     color: #FFFFFF;
     z-index: 15;
-  }
+}
 
-  .paragraphTextThree {
+.paragraphTextThree {
     width: 350px;
     height: 238px;
     margin-left: 20px;
     /* top: 567px; */
     margin-top: -40px;
     /* B1 */
-
     font-family: 'Outfit 300';
     font-style: normal;
     font-weight: 300;
@@ -224,55 +238,61 @@ a {
     /* top: 567px; */
     padding-top: 2%;
     z-index: 1;
-  }
+}
 
-  .cooltriangle {
+.cooltriangle {
     margin-left: -40px;
     margin-top: 120px;
-    z-index: 1;
-  }
+    z-index: 3;
+}
 
-  .leftcarrot {
+.leftcarrot {
     margin-left: 100px;
     margin-right: -100px;
+    z-index: 2;
+}
+
+.mountain-image {
     z-index: 1;
-  }
+    position: absolute;
+    top: 0px;
+    height: 100vh;
+    background-color: #6FCF97;
+}
 
-  .mountain-image{
-    text-align: center;
-    z-index: 10;
-    width: auto;
-    height: auto;
-    margin-top: auto;
-    margin-bottom: auto;
-    transform: scale(2.5);
-    transform: translate(20%, -55%);
-    /* position: fixed; */
-    /* background-position: bottom; */
-  }
+.mtn-image {
+    position: absolute;
+    top: 0%;
+    right: 100%;
+    background-color: #6FCF97;
+}
 
-  .m-img{
-    width:100;
-    height:300%;
-    z-index: 20;
-  }
+.m-img {
+    height: 45vh;
+    z-index: 1;
+    position: relative;
+    left: -16vw;
+}
 
-  @media only screen and (max-device-height: 1000px) {
-    .mountain-image{
-      text-align: center;
-      z-index: 10;
-      width: auto;
-      height: auto;
-      margin-top: auto;
-      margin-bottom: auto;
-      transform: scale(1.2);
-      transform: translate(33%, -100%);
-      /* position: fixed; */
-      /* background-position: bottom; */
-    }
 
-    @media only screen and (max-device-height: 800px) {
-      .mountain-image{
+/* @media only screen and (max-device-height: 1000px) {
+    .m-img {
+        transform: scale(1.2);
+        width: 40vw;
+        height: 40vh;
+        z-index: 20;
+        z-index: 20;
+        /* position: fixed; */
+
+
+/* background-position: bottom; */
+
+
+/*
+
+}
+@media only screen and (max-device-height: 800px) {
+    .m-img {
         text-align: center;
         z-index: 10;
         width: auto;
@@ -282,12 +302,12 @@ a {
         transform: scale(1.2);
         transform: translate(24%, -80%);
         /* position: fixed; */
-        /* background-position: bottom; */
-      }
+
+
+/* background-position: bottom; */
+
+
+/*
     }
-
-  }
-
-  
-
-  
+}
+*/

--- a/src/component/AboutPage/GrowthMantra/style.css
+++ b/src/component/AboutPage/GrowthMantra/style.css
@@ -10,16 +10,37 @@ a {
 }
 
 .background-fit-content {
-    width: fit-content;
+    width: 125vw;
+    max-width: 180vw;
+    background-color: white;
+    height: 100vh;
+}
+
+@media (min-aspect-ratio: 14/9) {
+    .background-fit-content {
+        width: 110vw;
+        max-width: 140vw;
+        background-color: white;
+        height: 100vh;
+    }
+}
+
+@media (min-aspect-ratio: 9/6) {
+    .background-fit-content {
+        width: 115vw;
+        max-width: 140vw;
+        background-color: white;
+        height: 100vh;
+    }
 }
 
 .growthMantraContainer {
     width: 155vw;
     margin-right: 12vw;
+    height: 100vh;
 }
 
 .Growth-text {
-    width: 1103px;
     z-index: 1;
     margin-bottom: 0px;
     /* top: -51px; */
@@ -34,7 +55,6 @@ a {
 }
 
 .IsOurText {
-    width: 40vw;
     left: 124px;
     z-index: 1;
     /* top: 288px; */
@@ -45,23 +65,20 @@ a {
     font-style: normal;
     font-weight: 700;
     font-size: max(9vh, 92px);
-    line-height: 95%;
+    line-height: 90%;
     margin-bottom: 0px;
     text-transform: uppercase;
 }
 
 .MantraText {
-    width: 50vw;
-    height: auto;
     left: 126px;
     z-index: 1;
-    margin-top: -40px;
     font-family: 'Space Mono 700';
     font-style: normal;
     /* font-weight: 700; */
     font-size: max(20vh, 200px);
     margin-bottom: 0px;
-    line-height: 90%;
+    line-height: 80%;
     text-transform: uppercase;
     /* Black */
     color: #111111;
@@ -149,11 +166,10 @@ a {
     z-index: 1;
 }
 
-.mantra {
+.mantraAlignment {
     display: flex;
     flex-direction: column;
     padding-top: 12vh;
-    width: 60%;
     z-index: 1;
 }
 
@@ -274,40 +290,95 @@ a {
     left: -16vw;
 }
 
-
-/* @media only screen and (max-device-height: 1000px) {
+@media (max-width: 650px) or (max-device-width: 650px) {
+    .alignItemsRightMantra {
+        display: flex;
+        flex-direction: row;
+        margin-right: 0;
+        margin-top: 0px;
+        padding-left: 3vw;
+        padding-right: 3vw;
+        align-items: center;
+        color: #000000;
+        z-index: 1;
+    }
+    .mantraAlignment {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding-top: 15vh;
+        margin-left: 0px;
+        width: 94vw;
+        z-index: 1;
+    }
+    .Growth-text {
+        z-index: 1;
+        margin-bottom: 0px;
+        font-family: 'Space Mono 700';
+        font-style: normal;
+        font-size: max(25vw, 99px);
+        line-height: 100%;
+        text-transform: uppercase;
+        /* OPRATN Green */
+        color: #6FCF97;
+    }
+    .IsOurText {
+        left: 124px;
+        z-index: 1;
+        -webkit-text-fill-color: transparent;
+        -webkit-text-stroke-width: max(0.2vh, 1.5px);
+        font-family: 'Space Mono 700';
+        font-style: normal;
+        font-weight: 700;
+        font-size: max(9vw, 48px);
+        line-height: 110%;
+        margin-bottom: 0px;
+        text-transform: uppercase;
+    }
+    .MantraText {
+        z-index: 1;
+        font-family: 'Space Mono 700';
+        font-style: normal;
+        /* font-weight: 700; */
+        font-size: max(20vw, 80px);
+        margin-bottom: 0px;
+        line-height: 100%;
+        text-transform: uppercase;
+        /* Black */
+        color: #111111;
+    }
+    .textAlignItemsRight {
+        padding-top: 5vh;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        padding-left: 3.5vw;
+        padding-right: 3.5vw;
+        color: #000000;
+        z-index: 1;
+    }
     .m-img {
-        transform: scale(1.2);
-        width: 40vw;
-        height: 40vh;
-        z-index: 20;
-        z-index: 20;
-        /* position: fixed; */
-
-
-/* background-position: bottom; */
-
-
-/*
-
-}
-@media only screen and (max-device-height: 800px) {
-    .m-img {
-        text-align: center;
-        z-index: 10;
-        width: auto;
-        height: auto;
-        margin-top: auto;
-        margin-bottom: auto;
-        transform: scale(1.2);
-        transform: translate(24%, -80%);
-        /* position: fixed; */
-
-
-/* background-position: bottom; */
-
-
-/*
+        display: none;
+    }
+    .mantraParagraphText {
+        width: 93vw;
+        height: fit-content;
+        text-align: left;
+        font-family: 'Outfit 300';
+        font-size: max(5vw, 24px);
+        font-style: normal;
+        font-weight: 300;
+        line-height: 140%;
+        margin-bottom: 6vh;
+        color: #111111;
+        z-index: 3;
+    }
+    .background-fit-content {
+        width: 100vw;
+        height: fit-content;
+    }
+    .growthMantraContainer {
+        width: 100vw;
+        height: fit-content;
     }
 }
-*/

--- a/src/component/AboutPage/style.css
+++ b/src/component/AboutPage/style.css
@@ -19,8 +19,6 @@
     height: 75vh;
 }
 
-
-
 h2 {
     font-family: 'Space Mono 700';
     font-size: 7vw;
@@ -58,6 +56,7 @@ p {
 
 
 /* TODO: delete after move to public */
+
 .fit-content {
     height: fit-content;
     width: fit-content;
@@ -90,57 +89,11 @@ p {
     .mobile {
         padding-left: 0% !important;
     }
-
-    .growthMantraContainer {
-        width: 100%;
-        padding-bottom: 10%;
-    }
-
-    .mantra {
-        padding: 0;
-        padding-top: 10%;
-        width: -moz-fit-content;
-        width: fit-content;
-        margin-left: auto;
-        margin-right: auto;
-    }
-
-    .Growth-text, .IsOurText, .MantraText {
-        width: unset;
-        text-align: center;
-        height: auto;
-        margin-top: 0;
-        line-height: 100%;
-    }
-
-    .Growth-text {
-        font-size: 24.5vw;
-    }
-
-    .IsOurText {
-        font-size: 12vw;
-    }
-
-    .MantraText {
-        font-size: 20.5vw;
-    }
-
-    .paragraphTextGrowthMantra, .paragraphTextGrowthMantraTwo {
-        font-size: 4.5vw;
-        line-height: 4vh;
-        width: unset;
-        height: unset;
-        margin: 0 auto;
-        padding-top: 10%;
-        width: 95%;
-    }
-
     .about-page .interestedText {
         margin-top: 20%;
     }
-
     .about-page .interestedcontainer {
-        background-size: 65%; 
+        background-size: 65%;
         background-position: 80% 10%;
     }
 }

--- a/src/component/Footer/VerticalFooter/index.js
+++ b/src/component/Footer/VerticalFooter/index.js
@@ -23,9 +23,10 @@ function VerticalFooter() {
           onClick={handleOnClick}
           alt='Logo description' // Add alt text to the image for accessibility
         />
-      </div>
+      </div>{' '}
       <div className='vert-footer-links-general'>
         <div className='vert-footer-pages'>
+          {' '}
           {pages.map((page, index) => (
             <div className='p-2'>
               <FooterLink
@@ -34,13 +35,15 @@ function VerticalFooter() {
                 currentPage={currentPageUrl.substring(
                   currentPageUrl.lastIndexOf('/')
                 )}
-              />
+              />{' '}
             </div>
-          ))}
-        </div>
+          ))}{' '}
+        </div>{' '}
         <div className='vert-social-icons'>
+          {' '}
           {socialIcons.map((row, index) => (
-            <Row key={index}>
+            <Row key={index} style={{ marginTop: '12px' }}>
+              {' '}
               {row.map((icon, index) => (
                 <>
                   <SocialIcon
@@ -48,20 +51,20 @@ function VerticalFooter() {
                     href={icon.href}
                     imgSrc={icon.imgSrc}
                     className='vert-icon'
-                  />
+                  />{' '}
                   {icon.href.includes('instagram') && (
                     <Col className='vert-icon'>
                       <a>
                         <div className='social-media' alt='' />
-                      </a>
+                      </a>{' '}
                     </Col>
-                  )}
+                  )}{' '}
                 </>
-              ))}
+              ))}{' '}
             </Row>
-          ))}
-        </div>
-      </div>
+          ))}{' '}
+        </div>{' '}
+      </div>{' '}
     </Col>
   )
 }

--- a/src/component/Footer/style.css
+++ b/src/component/Footer/style.css
@@ -1,184 +1,185 @@
 a {
-  text-decoration: none;
-  color: #ffffff;
+    text-decoration: none;
+    color: #ffffff;
 }
 
 .vert-top-level-contaner {
-  height: 100vh;
-  background-color: #187dff;
-  padding-left: 5vh;
-  padding-right: 5vh;
+    height: 100vh;
+    background-color: #187dff;
+    padding-left: 5vh;
+    padding-right: 5vh;
 }
 
 .vert-logo-placement {
-  width: 12vh;
-  height: 15vh;
+    width: 12vh;
+    height: 15vh;
 }
 
 .vert-footer-container {
-  background-color: #187dff;
-  width: auto;
-  height: 100vh;
-  overflow: hidden;
-  text-align: left;
-  float: left;
+    background-color: #187dff;
+    width: auto;
+    height: 100vh;
+    overflow: hidden;
+    text-align: left;
+    float: left;
 }
 
 .footer-link-bold {
-  font-weight: 600;
-  color: #ffffff;
-  white-space: nowrap;
-  max-height: 30px;
-  font-size: 2vh;
+    font-weight: 600;
+    color: #ffffff;
+    white-space: nowrap;
+    max-height: 30px;
+    font-size: 2vh;
 }
 
 .footer-link-text {
-  color: #ffffff;
-  font-weight: 400;
-  white-space: nowrap;
-  max-height: 30px;
-  font-size: 2vh;
-  font-family: 'Space Mono';
+    color: #ffffff;
+    font-weight: 400;
+    white-space: nowrap;
+    max-height: 30px;
+    font-size: 2vh;
+    font-family: 'Space Mono';
 }
 
 .vert-footer-links-general {
-  display: flex;
-  flex-direction: column;
-  height: 70vh;
-  margin-top: 60px;
+    display: flex;
+    flex-direction: column;
+    height: 70vh;
+    margin-top: 60px;
 }
 
 .vert-social-icons {
-  margin-top: auto;
+    margin-top: auto;
 }
 
 a:hover {
-  font-weight: 1000;
-  color: #ffffff;
+    font-weight: 1000;
+    color: #ffffff;
 }
 
 .vert-sherm {
-  /* margin-top: 25%; */
-  display: flex;
-  margin-top: 5vh;
-  flex-direction: row;
-  justify-content: center;
-  margin-left: 0%;
+    /* margin-top: 25%; */
+    display: flex;
+    margin-top: 5vh;
+    flex-direction: row;
+    justify-content: center;
+    margin-left: 0%;
 }
 
 .vert-sherm-placement {
-  display: flex;
-  margin-top: 5vh;
-  flex-direction: row;
-  justify-content: center;
+    display: flex;
+    margin-top: 5vh;
+    flex-direction: row;
+    justify-content: center;
 }
 
 .vert-icon {
-  height: 75px;
+    height: 75px;
+    margin-top: 3vh;
 }
 
 .footer-container-mobile {
-  background-color: #187dff;
-  text-align: left;
-  padding-left: 15vw;
-  padding-top: 5vh;
-  padding-right: 15vw;
-  padding-bottom: 5vh;
-  width: 100vw;
-  margin: 0;
-  height: auto;
+    background-color: #187dff;
+    text-align: left;
+    padding-left: 15vw;
+    padding-top: 5vh;
+    padding-right: 15vw;
+    padding-bottom: 5vh;
+    width: 100vw;
+    margin: 0;
+    height: auto;
 }
 
 .left-bar-item {
-  display: flex;
-  flex-direction: column;
+    display: flex;
+    flex-direction: column;
 }
 
 .footer-text {
-  height: 30px;
-  font-family: 'Space Mono';
-  font-style: normal;
-  font-weight: 400;
-  font-size: 40px;
-  line-height: 30px;
-  color: #ffffff;
-  padding-left: 15%;
-  margin: 5%;
+    height: 30px;
+    font-family: 'Space Mono';
+    font-style: normal;
+    font-weight: 400;
+    font-size: 40px;
+    line-height: 30px;
+    color: #ffffff;
+    padding-left: 15%;
+    margin: 5%;
 }
 
 .hor-footer-links {
-  display: flex;
-  flex-direction: column;
-  margin-top: auto;
+    display: flex;
+    flex-direction: column;
+    margin-top: auto;
 }
 
 .hor-icon {
-  height: fit-content;
-  margin-bottom: 40px;
+    height: fit-content;
+    margin-bottom: 40px;
 }
 
 .hor-icon {
-  height: fit-content;
+    height: fit-content;
 }
 
 .sherm {
-  padding: 5%;
-  margin-top: 0;
+    padding: 5%;
+    margin-top: 0;
 }
 
 .logo-placement {
-  width: 14vh;
-  height: 18vh;
+    width: 14vh;
+    height: 18vh;
 }
 
 .hor-social-icons {
-  margin-top: auto;
-  display: flex;
-  flex-direction: column-reverse;
+    margin-top: auto;
+    display: flex;
+    flex-direction: column-reverse;
 }
 
 .footer-two {
-  background-color: orange;
-  align-items: right;
+    background-color: orange;
+    align-items: right;
 }
 
 .rectangle {
-  display: inline-block;
-  width: 100px;
-  height: 100px;
-  background: black;
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+    background: black;
 }
 
 .rectangleLogo {
-  margin-left: 50px;
-  margin-top: 20px;
-  width: 90px;
-  height: 90px;
-  background: black;
+    margin-left: 50px;
+    margin-top: 20px;
+    width: 90px;
+    height: 90px;
+    background: black;
 }
 
 .social-media {
-  width: 2vw;
-  height: 3vh;
+    width: 2vw;
+    height: 3vh;
 }
 
 @media (max-width: 1200px) {
-  .social-media {
-    width: 4vw;
-    height: 9vh;
-  }
+    .social-media {
+        width: 4vw;
+        height: 9vh;
+    }
 }
 
 @media (max-width: 650px) {
-  .social-media {
-    width: 5vw;
-    height: 3.5vh;
-  }
+    .social-media {
+        width: 5vw;
+        height: 3.5vh;
+    }
 }
 
 @media (max-device-width: 650px) {
-  .social-media {
-    width: 6vw;
-    height: 4vh;
-  }
+    .social-media {
+        width: 6vw;
+        height: 4vh;
+    }
 }


### PR DESCRIPTION
# What was the ticket?

Hotfix - noticed by Leroy on Sep 29th

# What did I do?

Removed reliance on exact pixel dimensions on the growth page, which made it look wonky

# How did I test it?

Ran the frontend locally, and tested on two separate monitors, making sure behavior looked reasonable for reasonable web display
[ going to make sure it works in mobile too, tomorrow]

Required checks:

- [x] Did you conduct a self-review?
- [x] Have you written unit or integration tests?

# What could go wrong in the future? What parts of your code should the reviewer pay the most attention to?

Describe aspects of the PR that may become problems in the future.

# Additional Comments for the Reviewers

# Screenshots
![Screenshot 2023-09-29 at 10 41 05 AM](https://github.com/GenerateNU/website/assets/9142777/d119e4f9-8e00-4c29-8e00-43a898054bca)
![Screenshot 2023-09-29 at 10 40 53 AM](https://github.com/GenerateNU/website/assets/9142777/ed438aa5-053d-46af-beca-f5d07beee695)
![Screenshot 2023-09-29 at 10 00 23 AM](https://github.com/GenerateNU/website/assets/9142777/ed44f437-8661-44c9-8e03-42764768f7a1)
<img width="1356" alt="Screenshot 2023-09-29 at 9 59 47 AM" src="https://github.com/GenerateNU/website/assets/9142777/971376f1-9090-428f-88bb-9c48c668a012">
<img width="1082" alt="Screenshot 2023-09-29 at 9 59 31 AM" src="https://github.com/GenerateNU/website/assets/9142777/5ae8e280-4ad1-4113-a619-d8f60ce56360">
<img width="376" alt="Screenshot 2023-09-29 at 9 59 12 AM" src="https://github.com/GenerateNU/website/assets/9142777/1c840596-9585-439a-97a4-92dbedb9aa94">
<img width="376" alt="Screenshot 2023-09-29 at 9 59 05 AM" src="https://github.com/GenerateNU/website/assets/9142777/acb22b09-533a-480e-a6c2-6f4c9db6d4ec">



FIGMA

![alt text](public/images/PRImages/link_to_figma_image.png?raw=true "FIGMA")

MY VERSION

![alt text](public/images/PRImages/link_to_my_version_image.png?raw=true "LOCAL")

