### PR TITLE
fix mobile for new apply card colorings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,8 +4,8 @@
 <head>
   <meta charset="utf-8" />
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-  <!-- <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0" />
-  <meta name="apple-mobile-web-app-capable" content="yes" /> -->
+  <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0" />
+  <!-- <meta name="apple-mobile-web-app-capable" content="yes" /> -->
   <link rel="icon" href="images/LandingPageImages/generate_logo.png">
   <!-- <meta name="theme-color" content="#000000" /> -->
   <link rel="stylesheet" type="text/css" href="/css/style.css">

--- a/src/component/SocialIcon.jsx
+++ b/src/component/SocialIcon.jsx
@@ -56,7 +56,7 @@ export function SocialIcon({ href, imgSrc, className }) {
         <SvgIcon
           inheritViewBox
           sx={{
-            fontSize: mobile ? '64px' : '32px',
+            fontSize: mobile ? '32px' : '32px',
             '&:hover': { color: 'black' }
           }}
           component={imgSrc}

--- a/src/pages/ApplyPageV2/TeamApplicationCard/style.css
+++ b/src/pages/ApplyPageV2/TeamApplicationCard/style.css
@@ -66,10 +66,11 @@
 .team-header {
   font-family: 'Space Mono 700';
   color: black;
-  font-size: 4em;
+  font-size: 3rem;
   line-height: 100%;
   text-transform: uppercase;
 }
+
 
 .team-subheader {
   color: white;

--- a/src/pages/ApplyPageV2/index.js
+++ b/src/pages/ApplyPageV2/index.js
@@ -17,8 +17,8 @@ const desktopContent = (firstColumn, secondColumn) => {
         <div className='navbar-style'>
           <NavBar />
         </div>
-        <div className='join-header'>{header}</div>
-        <div className='join-text'>{quote}</div>
+        <h2 className='join-header'>{header}</h2>
+        <p className='join-text'>{quote}</p>
         <div className='column-container'>
           <div className='left-column'>
             {firstColumn.map((team) => (
@@ -44,7 +44,7 @@ const mobileContent = (teams) => {
         <div className='navbar-style'>
           <NavBar />
         </div>
-        <div className='join-header'>{header}</div>
+        <h2 className='join-header'>{header}</h2>
         <div className='join-text'>{quote}</div>
         <div className='mobile-column'>
           {teams.map((team) => (

--- a/src/pages/ApplyPageV2/style.css
+++ b/src/pages/ApplyPageV2/style.css
@@ -1,4 +1,6 @@
 .join-header {
+    width: 100%;
+    text-align: start;
     color: #FFF;
     font-family: 'Space Mono 700';
     font-size: 10vw;


### PR DESCRIPTION
## What I did

- Adjusted <meta> tag to scale the way most websites do on mobile (we were forcing them to render a desktop version)
- Fixed footer icons in response
- Reduced text size of team from 4em to 3rem to fit at both mobile and desktop sizes
- Converted some div to h2/p tags

<br />

- Configured Netlify to show a link to the Deploy Preview so you can poke around it before merging!