### PR TITLE
CLEAN: Remove the showcase popup on load

### DIFF
--- a/src/pages/LandingPageV3/index.js
+++ b/src/pages/LandingPageV3/index.js
@@ -10,20 +10,13 @@ import ParentOrgs from './ParentOrgs'
 import Footer from './Footer'
 import Sponsors from './Sponsors'
 import { Dialog } from '@headlessui/react'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 
 import './style.css'
 
 export default function LandingPageV3() {
   const whatIsGenerateRef = useRef(null)
-  const [isOpen, setIsOpen] = useState(false)
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsOpen(true)
-    }, 2000)
-    return () => clearTimeout(timer)
-  }, []) 
+  const [isOpen, setIsOpen] = useState(false) // <-- Set to true to enable the popup and change the link below
 
   return (
     <div id='page-bg'>
@@ -35,10 +28,9 @@ export default function LandingPageV3() {
         <iframe
           id='luma'
           title='luma'
-          src='https://luma.com/embed/event/evt-qcaL1sDb6Cg68Am/simple'
+          src='https://luma.com/embed/event/..../simple' // <-- Luma embedded link
           width='100%'
           height='100%'
-          frameBorder='0'
           style={{ border: 'none' }}
           allow='fullscreen; payment'
           aria-hidden='false'


### PR DESCRIPTION
# What did I do?

I removed the logic to display the popup for the showcase luma on the website on mount and restored Frank's comment about what to change to allow for it to be easily be changed in the future.

In the future, we should think about moving this to sanity but we should do the redesign first.

Required checks:

- [X] Did you conduct a self-review?
- [ ] Have you written unit or integration tests?

# What could go wrong in the future? What parts of your code should the reviewer pay the most attention to?

Describe aspects of the PR that may become problems in the future.

# Additional Comments for the Reviewers

# Screenshots

<img width="2124" height="1289" alt="image" src="https://github.com/user-attachments/assets/522eafbd-7a00-4334-8eb4-dbb439b92333" />

