### PR TITLE
Bug: Left Arrow on Mobile Moves Showcase Carousel Right

### DIFF
--- a/src/pages/LandingPageV3/CelebrateOurWins/index.js
+++ b/src/pages/LandingPageV3/CelebrateOurWins/index.js
@@ -120,7 +120,7 @@ export default function CelebrateOurWins() {
             <div id='small-carousel-nav'>
               <button
                 className='sm-carousel-button'
-                onClick={handleRightButtonClick}
+                onClick={handleLeftButtonClick}
               >
                 <PrevArrow />
               </button>


### PR DESCRIPTION
# What was the ticket?

WT - 233 - Left Arrow on Mobile Moves Showcase Carousel Right

Ticket Link: [https://github.com/GenerateNU/website/issues/233](https://github.com/GenerateNU/website/issues/233)

# What did I do?

I changed the handler that is being used for the "small" version of the showcase carousel to properly decrement the carousel when clicking left.

# How did I test it?

I clicked the button and it work. I click the right button and it also work :)
The larger carousel also still works :)

Required checks:

- [X] Did you conduct a self-review?
- [ ] Have you written unit or integration tests? 

# Additional Comments for the Reviewers

# Screenshots

<img width="1108" height="845" alt="image" src="https://github.com/user-attachments/assets/317b7087-301e-40a1-b761-0d48eef6f5d0" />




