### PR TITLE
Bug: Normalize shwocase data order and semester

### DIFF
--- a/src/pages/LandingPageV3/CelebrateOurWins/index.js
+++ b/src/pages/LandingPageV3/CelebrateOurWins/index.js
@@ -17,8 +17,14 @@ export default function CelebrateOurWins() {
     data
       ? data.map((showcase) => ({
           ...showcase,
+          semester: showcase.semester.toUpperCase(),
           image: urlFor(showcase.image)
-        }))
+        })).sort((a, b) => {
+          if (a.year === b.year){
+            return a.semester == "SPRING" ? -1 : 1
+          } 
+          return a.year - b.year
+        })
       : []
   )
 


### PR DESCRIPTION
# What was the ticket?

WT-236 - Bug: Ordering of the Showcase Carousel is Inconsistent #236

Ticket Link: https://github.com/GenerateNU/website/issues/236

# What did I do?
Enforced the ordering first by the year and then by the semester, with spring coming before fall in the ordering. 

# How did I test it?
For every year in the list, spring always comes before fall in the ordering. 

Required checks:

- [X] Did you conduct a self-review?
- [ ] Have you written unit or integration tests?

# What could go wrong in the future? What parts of your code should the reviewer pay the most attention to?

Describe aspects of the PR that may become problems in the future.

# Additional Comments for the Reviewers

# Screenshots

FIGMA

![alt text](public/images/PRImages/link_to_figma_image.png?raw=true "FIGMA")

MY VERSION

![alt text](public/images/PRImages/link_to_my_version_image.png?raw=true "LOCAL")

